### PR TITLE
feat: Expose Email Sending Methods in Controller

### DIFF
--- a/src/main/java/peppertech/crm/api/Mail/Controller/EmailController.java
+++ b/src/main/java/peppertech/crm/api/Mail/Controller/EmailController.java
@@ -9,10 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import peppertech.crm.api.Mail.Model.DTO.EmailDTO;
+import peppertech.crm.api.Mail.Model.Entity.EmailDetails;
 import peppertech.crm.api.Mail.Service.EmailServiceI;
 import peppertech.crm.api.Responses.ErrorResponse;
 
@@ -70,6 +69,25 @@ public class EmailController {
             return new ResponseEntity<>(emailServiceI.getAllMails(), HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(new ErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND.value()), HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @PostMapping("/send")
+    @Operation(summary = "Enviar y registrar correo",
+            description = "Envía un correo electrónico y lo almacena en la base de datos.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Correo enviado y registrado correctamente.",
+                        content = @Content(mediaType = "application/json", schema = @Schema(implementation = EmailDTO.class))),
+                @ApiResponse(responseCode = "400", description = "Solicitud inválida.",
+                        content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+                @ApiResponse(responseCode = "500", description = "Error interno al enviar el correo.",
+                        content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    public ResponseEntity<?> sendAndSaveMail(@RequestBody EmailDTO emailDetails) {
+        try {
+            return new ResponseEntity<>(emailServiceI.sendSimpleMail(emailDetails), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new ErrorResponse("Error al enviar el correo: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR.value()), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/peppertech/crm/api/Mail/Service/EmailServiceI.java
+++ b/src/main/java/peppertech/crm/api/Mail/Service/EmailServiceI.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface EmailServiceI {
 
-    void sendSimpleMail(EmailDetails details);
+    EmailDTO sendSimpleMail(EmailDTO emailDTO) ;
 
-    void sendMailWithAttachment(EmailDetails details);
+    EmailDTO sendMailWithAttachment(EmailDTO emailDTO);
 
     List<EmailDTO> getAllMails() throws Exception;
 }


### PR DESCRIPTION
Modify EmailService and its interface to expose email-sending functionalities via the controller. Update methods to improve error handling and repository persistence. Implement sendSimpleMail(EmailDTO emailDTO) to send plain-text emails and sendMailWithAttachment(EmailDTO emailDTO) to handle emails with attachments. Enhance exception handling using ValidationException and ensure proper entity-to-DTO conversion with emailMapper