### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   deployment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/1](https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves operations like checking out code, building Docker images, and triggering deployments, the following permissions are appropriate:

- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images.
- `id-token: write` for authentication if required by external services.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `deployment` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
