### PR TITLE
Potential fix for code scanning alert no. 5: Overly permissive regular expression range

### DIFF
--- a/src/main/java/peppertech/crm/api/Leads/Validator/LeadRegex.java
+++ b/src/main/java/peppertech/crm/api/Leads/Validator/LeadRegex.java
@@ -17,7 +17,7 @@ public class LeadRegex {
      * La longitud permitida es de 4 a 15 caracteres.
      * </p>
      */
-    public static final String NAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,15}$";
+    public static final String NAME_PATTERN = "^[a-zA-ZÁÉÍÓÚáéíóúñÑ]{4,15}$";
 
     /**
      * Expresión regular para validar el apellido de un lead.
@@ -26,7 +26,7 @@ public class LeadRegex {
      * La longitud permitida es de 4 a 30 caracteres.
      * </p>
      */
-    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,30}$";
+    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁÉÍÓÚáéíóúñÑ]{4,30}$";
 
     /**
      * Expresión regular para validar la dirección de correo electrónico de un lead.


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/5](https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/5)

To fix the issue, we need to refine the regular expression to avoid overlapping ranges and ensure it matches only the intended characters. Instead of using `Á-ÿ` and `á-ÿ`, we can explicitly list the accented characters that are valid for names. This approach avoids ambiguity and ensures the regex is precise.

For example, we can replace `Á-ÿ` and `á-ÿ` with explicit character classes that include uppercase and lowercase accented letters commonly used in names. This ensures the regex matches only valid characters without including unintended ones.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
