### PR TITLE
Potential fix for code scanning alert no. 7: Overly permissive regular expression range

### DIFF
--- a/src/main/java/peppertech/crm/api/Users/Validator/UserRegex.java
+++ b/src/main/java/peppertech/crm/api/Users/Validator/UserRegex.java
@@ -16,7 +16,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 15 caracteres.
      * </p>
      */
-    public static final String NAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,15}$";
+    public static final String NAME_PATTERN = "^[a-zA-ZÁ-Úá-ú]{4,15}$";
 
     /**
      * Expresión regular para validar el apellido de un usuario.
@@ -25,7 +25,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 30 caracteres.
      * </p>
      */
-    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,30}$";
+    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-Úá-ú]{4,30}$";
 
     /**
      * Expresión regular para validar la dirección de correo electrónico de un usuario.


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/7](https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/7)

To fix the issue, we need to rewrite the regular expression to avoid overlapping ranges. Instead of using `Á-ÿ` and `á-ÿ` together, we can explicitly list the ranges for uppercase (`Á-Ú`) and lowercase (`á-ú`) accented characters. This ensures clarity and avoids unintended matches. The corrected regular expression for `NAME_PATTERN` and `LASTNAME_PATTERN` will explicitly define the intended character ranges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
