### PR TITLE
Potential fix for code scanning alert no. 8: Overly permissive regular expression range

### DIFF
--- a/src/main/java/peppertech/crm/api/Users/Validator/UserRegex.java
+++ b/src/main/java/peppertech/crm/api/Users/Validator/UserRegex.java
@@ -16,7 +16,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 15 caracteres.
      * </p>
      */
-    public static final String NAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,15}$";
+    public static final String NAME_PATTERN = "^[a-zA-ZÁ-ÖØ-öø-ÿ]{4,15}$";
 
     /**
      * Expresión regular para validar el apellido de un usuario.
@@ -25,7 +25,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 30 caracteres.
      * </p>
      */
-    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,30}$";
+    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-ÖØ-öø-ÿ]{4,30}$";
 
     /**
      * Expresión regular para validar la dirección de correo electrónico de un usuario.


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/8](https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/8)

To fix the issue, we will rewrite the character class to avoid overlapping ranges. Instead of using `Á-ÿ` and `á-ÿ`, we will explicitly define the ranges for uppercase and lowercase accented characters. This ensures that the regex is unambiguous and matches only the intended characters. Specifically, we will replace `Á-ÿ` with `Á-ÖØ-öø-ÿ`, which correctly represents the intended range of accented characters without overlap.

The changes will be applied to both `NAME_PATTERN` and `LASTNAME_PATTERN` since they share the same issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
