### PR TITLE
Potential fix for code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/peppertech/crm/api/Security/Config/SecurityConfiguration.java
+++ b/src/main/java/peppertech/crm/api/Security/Config/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
         }
 
         return httpSec
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(Customizer.withDefaults()) // Enable default CSRF protection
                 .cors(c -> c.configurationSource(corsConfig))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> {
                     authorizationManagerRequestMatcherRegistry.requestMatchers(publicRoutesList.toArray(new String[0])).permitAll();


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/2](https://github.com/PepperTechDev/PepperCRM-API/security/code-scanning/2)

To fix the issue, CSRF protection should be enabled by default. Instead of disabling CSRF protection entirely, you can configure it to allow specific endpoints or use tokens for CSRF validation. This ensures that the application is protected against CSRF attacks while maintaining functionality.

**Steps to fix:**
1. Remove the `csrf(AbstractHttpConfigurer::disable)` line from the `securityFilterChain` method.
2. Optionally, configure CSRF protection to allow specific endpoints or use CSRF tokens for validation if needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
